### PR TITLE
refactor the config code base and make it clearly

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -121,6 +121,7 @@ target_sources(kvrocks PRIVATE
         src/rocksdb_crc32c.h
         src/config.cc
         src/config.h
+        src/config_type.h
         src/stats.cc
         src/stats.h
         src/server.cc
@@ -204,6 +205,7 @@ target_sources(kvrocks2redis PRIVATE
         src/rocksdb_crc32c.h
         src/config.cc
         src/config.h
+        src/config_type.h
         src/stats.cc
         src/stats.h
         src/server.cc
@@ -258,6 +260,8 @@ add_executable(unittest
         src/redis_zset.cc
         src/redis_sortedint.cc
         src/redis_sortedint.h
+        src/redis_slot.cc
+        src/redis_slot.h
         src/util.cc
         src/storage.cc
         src/lock_manager.cc
@@ -287,7 +291,7 @@ add_executable(unittest
         tests/task_runner_test.cc
         tests/t_bitmap_test.cc
         tests/compact_test.cc
-        tests/log_collector_test.cc)
+        tests/log_collector_test.cc src/config_type.h)
 
 add_dependencies(unittest glog rocksdb snappy jemalloc)
 target_compile_features(unittest PRIVATE cxx_std_11)

--- a/kvrocks.conf
+++ b/kvrocks.conf
@@ -24,10 +24,6 @@ workers 8
 # Default: 1
 repl-workers 1
 
-# The value should be INFO, WARNING, ERROR, FATAL
-# Default: INFO
-loglevel INFO
-
 # By default kvrocks does not run as a daemon. Use 'yes' if you need it.
 # Note that kvrocks will write a pid file in /var/run/kvrocks.pid when daemonized.
 daemonize no
@@ -73,16 +69,10 @@ db-name change.me.db
 # Note that you must specify a directory here, not a file name.
 dir /tmp/kvrocks
 
-# The backup directory
-#
-# The DB will be written inside this directory
-# Note that you must specify a directory here, not a file name.
-# kvrocks will create backup directory in ${CONFIG_DIR}/backup by default.
-# backup-dir /tmp/kvrocks/backup
-
 # When running daemonized, kvrocks writes a pid file in ${CONFIG_DIR}/kvrocks.pid by
 # default. You can specify a custom pid file location here.
 # pidfile /var/run/kvrocks.pid
+pidfile ""
 
 # You can configure a slave instance to accept writes or not. Writing against
 # a slave instance may be useful to store some ephemeral data (because data
@@ -178,8 +168,24 @@ max-backup-keep-hours 168
 # Enable the kvrocks to support the codis protocol, if the db enabled the codis mode at first open, 
 # this option must not be disabled after restarted, and vice versa
 # Defalut: no
-# codis-enabled yes
+codis-enabled no
 
+# Ratio of the samples would be recorded when the profiling was enabled. 
+# we simply use the rand to determine whether to record the sample or not.
+# 
+# Default: 0
+profiling-sample-ratio 0
+
+# There is no limit to this length. Just be aware that it will consume memory.
+# You can reclaim memory used by the perf log with PERFLOG RESET.
+#
+# Default: 256
+profiling-sample-record-max-len 256
+
+# profiling-sample-record-threshold-ms use to tell the kvrocks when to record.
+#
+# Default: 100 millisecond
+profiling-sample-record-threshold-ms 100
 
 ################################## SLOW LOG ###################################
 
@@ -224,11 +230,10 @@ supervised no
 # would compact the db at 3am and 4am everyday
 compact-cron 0 3 * * *
 
-# Backup Scheduler, auto backup at schedule time
-# time expression format is the same as compact-cron
+# Bgsave scheduler, auto bgsave at schedule time
+# time expression format is the same as crontab(currently only support * and int)
 # e.g. compact-cron 0 3 * * * 0 4 * * *
-# would backup the db at 3am and 4am everyday
-# bgsave-cron 0 4 * * *
+# would bgsave the db at 3am and 4am everyday
 
 ################################ ROCKSDB #####################################
 
@@ -329,6 +334,43 @@ rocksdb.cache_index_and_filter_blocks no
 # Accept value: "no", "snappy"
 # default snappy
 rocksdb.compression snappy
+
+# If non-zero, we perform bigger reads when doing compaction. If you're
+# running RocksDB on spinning disks, you should set this to at least 2MB.
+# That way RocksDB's compaction is doing sequential instead of random reads.
+# When non-zero, we also force new_table_reader_for_compaction_inputs to
+# true.
+# 
+# Default: 2 MB
+rocksdb.compaction_readahead_size 2097152
+
+# he limited write rate to DB if soft_pending_compaction_bytes_limit or
+# level0_slowdown_writes_trigger is triggered.
+
+# If the value is 0, we will infer a value from `rater_limiter` value
+# if it is not empty, or 16MB if `rater_limiter` is empty. Note that
+# if users change the rate in `rate_limiter` after DB is opened,
+# `delayed_write_rate` won't be adjusted.
+#
+rocksdb.delayed_write_rate 0
+# If enable_pipelined_write is true, separate write thread queue is
+#  maintained for WAL write and memtable write.
+#
+#  Default: yes
+rocksdb.enable_pipelined_write yes
+
+# Soft limit on number of level-0 files. We start slowing down writes at this
+#  point. A value <0 means that no writing slow down will be triggered by
+# number of files in level-0.
+#
+# Default: 20
+rocksdb.level0_slowdown_writes_trigger 20
+
+# if not zero, dump rocksdb.stats to LOG every stats_dump_period_sec
+#
+# Default: 0
+rocksdb.stats_dump_period_sec 0
+
 
 ################################ NAMESPACE #####################################
 # namespace.test change.me

--- a/src/config.cc
+++ b/src/config.cc
@@ -19,22 +19,24 @@
 #include "log_collector.h"
 
 const char *kDefaultNamespace = "__namespace";
-static const char *kLogLevels[] = {"info", "warning", "error", "fatal"};
-static const size_t kNumLogLevel = sizeof(kLogLevels)/ sizeof(kLogLevels[0]);
-static const char *kCompressionType[] = {"no", "snappy"};
-static const size_t kNumCompressionType = sizeof(kCompressionType) / sizeof(kCompressionType[0]);
-
-typedef struct configEnum {
-  const char *name;
-  const int val;
-} configEnum;
-
+configEnum compression_type_enum[] = {
+    {"no", rocksdb::CompressionType::kNoCompression},
+    {"snappy", rocksdb::CompressionType::kSnappyCompression},
+    {nullptr, 0}
+};
 configEnum supervised_mode_enum[] = {
     {"no", SUPERVISED_NONE},
     {"auto", SUPERVISED_AUTODETECT},
     {"upstart", SUPERVISED_UPSTART},
     {"systemd", SUPERVISED_SYSTEMD},
     {nullptr, 0}
+};
+
+ConfigField::~ConfigField() = default;
+
+std::string trimRocksDBPrefix (std::string s) {
+  if (strncasecmp(s.data(), "rocksdb.",8)) return s;
+  return s.substr(8, s.size()-8);
 };
 
 int configEnumGetValue(configEnum *ce, const char *name) {
@@ -53,262 +55,292 @@ const char *configEnumGetName(configEnum *ce, int val) {
   return nullptr;
 }
 
-void Config::incrOpenFilesLimit(rlim_t maxfiles) {
-  struct rlimit limit;
-
-  rlim_t old_limit, best_limit = maxfiles, decr_step = 16;
-  if (getrlimit(RLIMIT_NOFILE, &limit) < 0 || best_limit <= limit.rlim_cur) {
-    return;
+Config::Config() {
+  struct FieldWrapper {
+    const char *name;
+    bool readonly;
+    ConfigField *field;
+  };
+  std::vector<FieldWrapper> fields = {
+      {"daemonize", true, new YesNoField(&daemonize, false)},
+      {"bind", true, new StringField(&binds_, "127.0.0.1")},
+      {"repl-bind", true, new StringField(&repl_binds_, "127.0.0.1")},
+      {"port", true, new IntField(&port, 6666, 1, 65535)},
+      {"workers", true, new IntField(&workers, 8, 1, 256)},
+      {"repl-workers", true, new IntField(&repl_workers, 4, 1, 256)},
+      {"timeout", false, new IntField(&timeout, 0, 0, INT_MAX)},
+      {"tcp-backlog", true, new IntField(&backlog, 511, 0, INT_MAX)},
+      {"maxclients", false, new IntField(&maxclients, 10240, 0, INT_MAX)},
+      {"max-backup-to-keep", false, new IntField(&max_backup_to_keep, 1, 0, 64)},
+      {"max-backup-keep-hours", false, new IntField(&max_backup_keep_hours, 0, 0, INT_MAX)},
+      {"codis-enabled", true, new YesNoField(&codis_enabled, false)},
+      {"requirepass", false, new StringField(&requirepass, "")},
+      {"masterauth", false, new StringField(&masterauth, "")},
+      {"slaveof", true, new StringField(&slaveof_, "")},
+      {"compact-cron", false, new StringField(&compact_cron_, "")},
+      {"bgsave-cron", false, new StringField(&bgsave_cron_, "")},
+      {"db-name", true, new StringField(&db_name, "changeme.name")},
+      {"dir", true, new StringField(&dir, "/tmp/kvrocks")},
+      {"backup-dir", true, new StringField(&backup_dir, "")},
+      {"pidfile", true, new StringField(&pidfile, "")},
+      {"max-io-mb", false, new IntField(&max_io_mb, 500, 0, INT_MAX)},
+      {"max-db-size", false, new IntField(&max_db_size, 0, 0, INT_MAX)},
+      {"max-replication-mb", false, new IntField(&max_replication_mb, 0, 0, INT_MAX)},
+      {"supervised", true, new EnumField(&supervised_mode, supervised_mode_enum, SUPERVISED_NONE)},
+      {"slave-serve-stale-data", false, new YesNoField(&slave_serve_stale_data, true)},
+      {"slave-priority", false, new IntField(&slave_priority, 100, 0, INT_MAX)},
+      {"slave-read-only", false, new YesNoField(&slave_readonly, true)},
+      {"profiling-sample-ratio", false, new IntField(&profiling_sample_ratio, 0, 0, 100)},
+      {"profiling-sample-record-max-len", false, new IntField(&profiling_sample_record_max_len, 256, 0, INT_MAX)},
+      {"profiling-sample-record-threshold-ms",
+       false, new IntField(&profiling_sample_record_threshold_ms, 100, 0, INT_MAX)},
+      {"slowlog-log-slower-than", false, new IntField(&slowlog_log_slower_than, 200000, 0, INT_MAX)},
+      {"profiling-sample-commands", false, new StringField(&profiling_sample_commands_, "")},
+      {"slowlog-max-len", false, new IntField(&slowlog_max_len, 128, 0, INT_MAX)},
+      /* rocksdb options */
+      {"rocksdb.compression", false, new EnumField(&RocksDB.compression, compression_type_enum, 0)},
+      {"rocksdb.block_size", true, new IntField(&RocksDB.block_size, 4096, 0, INT_MAX)},
+      {"rocksdb.max_open_files", false, new IntField(&RocksDB.max_open_files, 4096, -1, INT_MAX)},
+      {"rocksdb.write_buffer_size", false, new IntField(&RocksDB.write_buffer_size, 64, 0, 4096)},
+      {"rocksdb.max_write_buffer_number", false, new IntField(&RocksDB.max_write_buffer_number ,4, 0, 256)},
+      {"rocksdb.target_file_size_base", true, new IntField(&RocksDB.target_file_size_base, 256, 1, 1024)},
+      {"rocksdb.max_background_compactions", false, new IntField(&RocksDB.max_background_compactions, 2, 0, 32)},
+      {"rocksdb.max_background_flushes", true, new IntField(&RocksDB.max_background_flushes, 2, 0, 32)},
+      {"rocksdb.max_sub_compactions", false, new IntField(&RocksDB.max_sub_compactions, 1, 0, 16)},
+      {"rocksdb.delayed_write_rate", false, new Int64Field(&RocksDB.delayed_write_rate, 0, 0, INT64_MAX)},
+      {"rocksdb.wal_ttl_seconds", true, new IntField(&RocksDB.WAL_ttl_seconds, 7*24*3600, 0, INT_MAX)},
+      {"rocksdb.wal_size_limit_mb", true, new IntField(&RocksDB.WAL_size_limit_MB, 5120, 0, INT_MAX)},
+      {"rocksdb.enable_pipelined_write", true, new YesNoField(&RocksDB.enable_pipelined_write, true)},
+      {"rocksdb.stats_dump_period_sec", false, new IntField(&RocksDB.stats_dump_period_sec, 0, 0, INT_MAX)},
+      {"rocksdb.cache_index_and_filter_blocks", true, new YesNoField(&RocksDB.cache_index_and_filter_blocks, false)},
+      {"rocksdb.subkey_block_cache_size", true, new IntField(&RocksDB.subkey_block_cache_size, 2048, 0, INT_MAX)},
+      {"rocksdb.metadata_block_cache_size", true, new IntField(&RocksDB.metadata_block_cache_size, 2048, 0, INT_MAX)},
+      {"rocksdb.compaction_readahead_size", false, new IntField(&RocksDB.compaction_readahead_size, 2*MiB, 0, 64*MiB)},
+      {"rocksdb.level0_slowdown_writes_trigger",
+       false, new IntField(&RocksDB.level0_slowdown_writes_trigger, 20, 1, 1024)},
+  };
+  for (const auto &wrapper : fields) {
+    auto field = wrapper.field;
+    field->readonly = wrapper.readonly;
+    fields_.insert({wrapper.name, field});
   }
-  old_limit = limit.rlim_cur;
-  while (best_limit > old_limit) {
-    limit.rlim_cur = best_limit;
-    limit.rlim_max = best_limit;
-    if (setrlimit(RLIMIT_NOFILE, &limit) != -1) break;
-    /* We failed to set file limit to 'bestlimit'. Try with a
-     * smaller limit decrementing by a few FDs per iteration. */
-    if (best_limit < decr_step) break;
-    best_limit -= decr_step;
-  }
+  initFieldValidator();
+  initFieldCallback();
 }
 
-void Config::array2String(const std::vector<std::string> &array,
-                          const std::string &delim, std::string *output) {
-  output->clear();
-  for (size_t i = 0; i < array.size(); i++) {
-    output->append(array[i]);
-    if (i != array.size()-1) output->append(delim);
-  }
-}
-
-int Config::yesnotoi(std::string input) {
-  if (strcasecmp(input.data(), "yes") == 0) {
-    return 1;
-  } else if (strcasecmp(input.data(), "no") == 0) {
-    return 0;
-  }
-  return -1;
-}
-
-Status Config::parseRocksdbOption(const std::string &key, std::string value) {
-  if (key == "compression") {
-    for (size_t i = 0; i < kNumCompressionType; i++) {
-      if (Util::ToLower(value) == kCompressionType[i]) {
-        rocksdb_options.compression = static_cast<rocksdb::CompressionType >(i);
-        break;
-      }
+// The validate function would be invoked before the field was set,
+// to make sure that new value is valid.
+void Config::initFieldValidator() {
+  std::map<std::string, validate_fn> validators = {
+      {"requirepass", [this](const std::string& k, const std::string& v)->Status {
+        if (v.empty() && !tokens.empty()) {
+          return Status(Status::NotOK, "requirepass empty not allowed while the namespace exists");
+        }
+        return Status::OK();
+      }},
+      {"compact-cron", [this](const std::string& k, const std::string& v)->Status {
+        std::vector<std::string> args;
+        Util::Split(v, " \t", &args);
+        return compact_cron.SetScheduleTime(args);
+      }},
+      {"bgsave-cron", [this](const std::string& k, const std::string& v)->Status {
+        std::vector<std::string> args;
+        Util::Split(v, " \t", &args);
+        return bgsave_cron.SetScheduleTime(args);
+      }},
+  };
+  for (const auto& iter: validators) {
+    auto field_iter = fields_.find(iter.first);
+    if (field_iter != fields_.end()) {
+      field_iter->second->validate = iter.second;
     }
-  } else if (key == "enable_pipelined_write")  {
-    rocksdb_options.enable_pipelined_write = value == "yes";
-  } else if (key == "cache_index_and_filter_blocks")  {
-    rocksdb_options.cache_index_and_filter_blocks = value == "yes";
-  } else {
-    return parseRocksdbIntOption(key, value);
   }
-  return Status::OK();
 }
 
-Status Config::parseRocksdbIntOption(std::string key, std::string value) {
-  int64_t n;
-  auto s = Util::StringToNum(value, &n);
-  if (key == "max_open_files") {
-    rocksdb_options.max_open_files = static_cast<int>(n);
-  }  else if (key == "block_size") {
-    rocksdb_options.block_size = static_cast<size_t>(n);
-  } else if (!strncasecmp(key.data(), "write_buffer_size" , strlen("write_buffer_size"))) {
-    rocksdb_options.write_buffer_size = static_cast<size_t>(n) * MiB;
-  }  else if (key == "max_write_buffer_number") {
-    rocksdb_options.max_write_buffer_number = static_cast<int>(n);
-  }  else if (key == "write_buffer_size") {
-    rocksdb_options.write_buffer_size = static_cast<uint64_t>(n);
-  }  else if (key == "target_file_size_base") {
-    rocksdb_options.target_file_size_base = static_cast<uint64_t>(n);
-  }  else if (key == "max_background_compactions") {
-    rocksdb_options.max_background_compactions = static_cast<int>(n);
-  }  else if (key == "max_background_flushes") {
-    rocksdb_options.max_background_flushes = static_cast<int>(n);
-  }  else if (key == "max_sub_compactions") {
-    rocksdb_options.max_sub_compactions = static_cast<uint32_t>(n);
-  } else if (key == "metadata_block_cache_size") {
-    rocksdb_options.metadata_block_cache_size = static_cast<size_t>(n) * MiB;
-  } else if (key == "subkey_block_cache_size") {
-    rocksdb_options.subkey_block_cache_size = static_cast<size_t>(n) * MiB;
-  } else if (key == "delayed_write_rate") {
-    rocksdb_options.delayed_write_rate = static_cast<uint64_t>(n);
-  } else if (key == "compaction_readahead_size") {
-    rocksdb_options.compaction_readahead_size = static_cast<size_t>(n);
-  } else if (key == "wal_ttl_seconds") {
-    rocksdb_options.WAL_ttl_seconds = static_cast<uint64_t>(n);
-  } else if (key == "wal_size_limit_mb") {
-    rocksdb_options.WAL_size_limit_MB = static_cast<uint64_t>(n);
-  } else if (key == "level0_slowdown_writes_trigger") {
-    rocksdb_options.level0_slowdown_writes_trigger = static_cast<int>(n);
-    rocksdb_options.level0_stop_writes_trigger = static_cast<int>(n*2);
-  } else {
-    return Status(Status::NotOK, "Bad directive or wrong number of arguments");
+// The callback function would be invoked after the field was set,
+// it may change related fileds or re-format the field. for example,
+// when the 'dir' was set, the db-dir or backup-dir should be reset as well.
+void Config::initFieldCallback() {
+  auto set_db_option_cb = [](Server* srv,  const std::string &k, const std::string& v)->Status {
+    if (!srv) return Status::OK();  // srv is nullptr when load config from file
+    return srv->storage_->SetDBOption(trimRocksDBPrefix(k), v);
+  };
+  std::map<std::string, callback_fn> callbacks = {
+      {"dir", [this](Server* srv,  const std::string &k, const std::string& v)->Status {
+        db_dir = dir + "/db";
+        if (backup_dir.empty()) backup_dir = dir + "/backup";
+        return Status::OK();
+      }},
+      {"port", [this](Server* srv,  const std::string &k, const std::string& v)->Status {
+        repl_port = port + 1;
+        return Status::OK();
+      }},
+      {"bind", [this](Server* srv,  const std::string &k,  const std::string& v)->Status {
+        trimRocksDBPrefix(k);
+        std::vector<std::string> args;
+        Util::Split(v, " \t", &args);
+        binds = std::move(args);
+        return Status::OK();
+      }},
+      {"repl-bind", [this](Server* srv,  const std::string &k, const std::string& v)->Status {
+        std::vector<std::string> args;
+        Util::Split(v, " \t", &args);
+        repl_binds = std::move(args);
+        return Status::OK();
+      }},
+      {"slaveof", [this](Server* srv, const std::string &k, const std::string& v)->Status {
+        std::vector<std::string> args;
+        Util::Split(v, " \t", &args);
+        if (args.size() != 2) return Status(Status::NotOK, "wrong number of arguments");
+        if (args[0] != "no" && args[1] != "one") {
+          master_host = args[0];
+          master_port = std::atoi(args[1].c_str());
+          if (master_port <= 0 || master_port >= 65535) {
+            return Status(Status::NotOK, "should be between 0 and 65535");
+          }
+        }
+        return Status::OK();
+      }},
+      {"profiling-sample-commands", [this](Server* srv, const std::string &k, const std::string& v)->Status {
+        std::vector<std::string> cmds;
+        Util::Split(v, ",", &cmds);
+        profiling_sample_all_commands = false;
+        profiling_sample_commands.clear();
+        for (auto const &cmd : cmds) {
+          if (cmd == "*") {
+            profiling_sample_all_commands = true;
+            profiling_sample_commands.clear();
+          } else if (Redis::IsCommandExists(cmd)) {
+            profiling_sample_commands.insert(cmd);
+          }
+        }
+        return Status::OK();
+      }},
+      {"slowlog-max-len", [this](Server* srv, const std::string &k, const std::string& v)->Status {
+        if (!srv) return Status::OK();
+        srv->GetSlowLog()->SetMaxEntries(slowlog_max_len);
+        return Status::OK();
+      }},
+      {"max-db-size", [](Server* srv, const std::string &k, const std::string& v)->Status {
+        if (!srv) return Status::OK();
+        srv->storage_->CheckDBSizeLimit();
+        return Status::OK();
+      }},
+      {"max-replication-mb", [this](Server* srv, const std::string &k, const std::string& v)->Status {
+        if (!srv) return Status::OK();
+        srv->SetReplicationRateLimit(static_cast<uint64_t>(max_replication_mb));
+        return Status::OK();
+      }},
+      {"max-io-mb", [this](Server* srv, const std::string &k, const std::string& v)->Status {
+        if (!srv) return Status::OK();
+        srv->storage_->SetIORateLimit(static_cast<uint64_t>(max_io_mb));
+        return Status::OK();
+      }},
+      {"profiling-sample-record-max-len", [this](Server* srv, const std::string &k, const std::string& v)->Status {
+        if (!srv) return Status::OK();
+        srv->GetPerfLog()->SetMaxEntries(profiling_sample_record_max_len);
+        return Status::OK();
+      }},
+      {"rocksdb.write_buffer_size", [this](Server* srv, const std::string &k, const std::string& v)->Status {
+        if (!srv) return Status::OK();
+        return srv->storage_->SetColumnFamilyOption(trimRocksDBPrefix(k),
+                                                    std::to_string(RocksDB.write_buffer_size * MiB));
+      }},
+      {"rocksdb.max_write_buffer_number", [](Server* srv, const std::string &k, const std::string& v)->Status {
+        if (!srv) return Status::OK();
+        return srv->storage_->SetColumnFamilyOption(trimRocksDBPrefix(k), v);
+      }},
+      {"rocksdb.level0_slowdown_writes_trigger", [this](Server* srv,
+                                                        const std::string &k, const std::string& v)->Status {
+        if (!srv) return Status::OK();
+        RocksDB.level0_stop_writes_trigger = RocksDB.level0_slowdown_writes_trigger * 2;
+        srv->storage_->SetColumnFamilyOption(trimRocksDBPrefix(k), v);
+        return srv->storage_->SetColumnFamilyOption("level0_stop_writes_trigger",
+                                                    std::to_string(RocksDB.level0_stop_writes_trigger));
+      }},
+      {"rocksdb.max_open_files", set_db_option_cb},
+      {"rocksdb.stats_dump_period_sec", set_db_option_cb},
+      {"rocksdb.delayed_write_rate", set_db_option_cb},
+      {"rocksdb.max_background_compactions", set_db_option_cb},
+      {"rocksdb.max_background_flushes", set_db_option_cb},
+      {"rocksdb.compaction_readahead_size",set_db_option_cb},
+  };
+  for (const auto& iter: callbacks) {
+    auto field_iter = fields_.find(iter.first);
+    if (field_iter != fields_.end()) {
+      field_iter->second->callback = iter.second;
+    }
   }
-  return Status::OK();
+}
+
+Config::~Config() {
+  for (const auto &iter : fields_) {
+    delete iter.second;
+  }
+}
+
+void Config::SetMaster(const std::string &host, int port) {
+  master_host = host;
+  master_port = port;
+  auto iter = fields_.find("slaveof");
+  if (iter != fields_.end()) {
+    iter->second->Set(master_host+" "+std::to_string(master_port));
+  }
+}
+
+void Config::ClearMaster() {
+  master_host.clear();
+  master_port = 0;
+  auto iter = fields_.find("slaveof");
+  if (iter != fields_.end()) {
+    iter->second->Set("no one");
+  }
 }
 
 Status Config::parseConfigFromString(std::string input) {
-  std::vector<std::string> args;
-  Util::Split(input, " \t\r\n", &args);
-  // omit empty line and comment
-  if (args.empty() || args[0].front() == '#') return Status::OK();
+  std::vector<std::string> kv;
+  Util::Split2KV(input, " \t", &kv);
 
-  args[0] = Util::ToLower(args[0]);
-  size_t size = args.size();
-  if (size == 2 && args[0] == "port") {
-    port = std::atoi(args[1].c_str());
-    repl_port = port + 1;
-  } else if (size == 2 && args[0] == "timeout") {
-    timeout = std::atoi(args[1].c_str());
-  } else if (size == 2 && args[0] == "workers") {
-    workers = std::atoi(args[1].c_str());
-    if (workers < 1 || workers > 1024) {
-      return Status(Status::NotOK, "too many worker threads");
+  // skip the comment and empty line
+  if (kv.empty() || kv[0].front() == '#') return Status::OK();
+
+  if (kv.size() != 2) return Status(Status::NotOK, "wrong number of arguments");
+  if(kv[1] == "\"\"") return Status::OK();
+
+  kv[0] = Util::ToLower(kv[0]);
+  auto iter = fields_.find(kv[0]);
+  if (iter != fields_.end()) {
+    auto field = iter->second;
+    if (field->validate) {
+      auto s = field->validate(kv[0], kv[1]);
+      if (!s.IsOK()) return s;
     }
-  } else if (size == 2 && args[0] == "repl-workers") {
-    repl_workers = std::atoi(args[1].c_str());
-    if (workers < 1 || workers > 1024) {
-      return Status(Status::NotOK, "too many replication worker threads");
+    auto s = field->Set(kv[1]);
+    if (!s.IsOK()) return s;
+    if (field->callback) {
+      return field->callback(nullptr, kv[0], kv[1]);
     }
-  } else if (size >= 2 && args[0] == "bind") {
-    binds.clear();
-    for (unsigned i = 1; i < args.size(); i++) {
-      binds.emplace_back(args[i]);
-    }
-  } else if (size >= 2 && args[0] == "repl-bind") {
-    repl_binds.clear();
-    for (unsigned i = 1; i < args.size(); i++) {
-      repl_binds.emplace_back(args[i]);
-    }
-  } else if (size == 2 && args[0] == "daemonize") {
-    int i;
-    if ((i = yesnotoi(args[1])) == -1) {
-      return Status(Status::NotOK, "argument must be 'yes' or 'no'");
-    }
-    daemonize = (i == 1);
-  } else if (size == 2 && args[0] == "slave-read-only") {
-    int i;
-    if ((i = yesnotoi(args[1])) == -1) {
-      return Status(Status::NotOK, "argument must be 'yes' or 'no'");
-    }
-    slave_readonly = (i == 1);
-  } else if (size == 2 && args[0] == "slave-serve-stale-data") {
-    int i;
-    if ((i = yesnotoi(args[1])) == -1) {
-      return Status(Status::NotOK, "argument must be 'yes' or 'no'");
-    }
-    slave_serve_stale_data = (i == 1);
-  } else if (size == 2 && args[0] == "slave-priority") {
-    slave_priority = std::atoi(args[1].c_str());
-  } else if (size == 2 && args[0] == "tcp-backlog") {
-    backlog = std::atoi(args[1].c_str());
-  } else if (size == 2 && args[0] == "dir") {
-    dir = args[1];
-    db_dir = dir + "/db";
-    pidfile = dir + "/kvrocks.pid";
-  } else if (size == 2 && args[0] == "backup-dir") {
-    backup_dir = args[1];
-  } else if (size == 2 && args[0] == "maxclients") {
-    maxclients = std::atoi(args[1].c_str());
-    if (maxclients > 0) incrOpenFilesLimit(static_cast<rlim_t >(maxclients));
-  } else if (size == 2 && args[0] == "db-name") {
-    db_name = args[1];
-  } else if (size == 2 && args[0] == "masterauth") {
-    masterauth = args[1];
-  } else if (size == 2 && args[0] == "max-backup-to-keep") {
-    max_backup_to_keep = static_cast<uint32_t>(std::atoi(args[1].c_str()));
-  } else if (size == 2 && args[0] == "max-backup-keep-hours") {
-    max_backup_keep_hours = static_cast<uint32_t>(std::atoi(args[1].c_str()));
-  } else if (size == 2 && args[0] == "codis-enabled") {
-    int i;
-    if ((i = yesnotoi(args[1])) == -1) {
-      return Status(Status::NotOK, "argument must be 'yes' or 'no'");
-    }
-    codis_enabled = (i == 1);
-  } else if (size == 2 && args[0] == "requirepass") {
-    requirepass = args[1];
-  } else if (size == 2 && args[0] == "pidfile") {
-    pidfile = args[1];
-  } else if (size == 2 && args[0] == "loglevel") {
-    for (size_t i = 0; i < kNumLogLevel; i++) {
-      if (Util::ToLower(args[1]) == kLogLevels[i]) {
-        loglevel = static_cast<int>(i);
-        break;
-      }
-    }
-  } else if (size == 3 && args[0] == "slaveof") {
-    if (args[1] != "no" && args[2] != "one") {
-      master_host = args[1];
-      master_port = std::atoi(args[2].c_str());
-      if (master_port <= 0 || master_port >= 65535) {
-        return Status(Status::NotOK, "master port range should be between 0 and 65535");
-      }
-    }
-  } else if (size == 2 && args[0] == "max-db-size") {
-    max_db_size = static_cast<uint32_t>(std::atoi(args[1].c_str()));
-  } else if (size == 2 && args[0] == "max-replication-mb") {
-    max_replication_mb = static_cast<uint64_t>(std::atoi(args[1].c_str()));
-  } else if (size == 2 && args[0] == "max-io-mb") {
-    max_io_mb = static_cast<uint64_t>(std::atoi(args[1].c_str()));
-  } else if (size >= 2 && args[0] == "compact-cron") {
-    args.erase(args.begin());
-    Status s = compact_cron.SetScheduleTime(args);
-    if (!s.IsOK()) {
-      return Status(Status::NotOK, "compact-cron time expression format error : "+s.Msg());
-    }
-  } else if (size >=2 && args[0] == "bgsave-cron") {
-    args.erase(args.begin());
-    Status s = bgsave_cron.SetScheduleTime(args);
-    if (!s.IsOK()) {
-      return Status(Status::NotOK, "bgsave-cron time expression format error : " + s.Msg());
-    }
-  } else if (size == 2 && args[0] == "profiling-sample-ratio") {
-    profiling_sample_ratio = std::atoi(args[1].c_str());
-    if (profiling_sample_ratio < 0 || profiling_sample_ratio > 100) {
-      return Status(Status::NotOK, "profiling_sample_ratio value should between 0 and 100");
-    }
-  } else if (size == 2 && args[0] == "profiling-sample-record-max-len") {
-    profiling_sample_record_max_len = std::atoi(args[1].c_str());
-  } else if (size == 2 && args[0] == "profiling-sample-record-threshold-ms") {
-    profiling_sample_record_threshold_ms = std::atoi(args[1].c_str());
-  } else if (size == 2 && args[0] == "profiling-sample-commands") {
-    std::vector<std::string> cmds;
-    Util::Split(args[1], ",", &cmds);
-    for (auto const &cmd : cmds) {
-      if (cmd == "*") {
-        profiling_sample_all_commands = true;
-        profiling_sample_commands.clear();
-        break;
-      }
-      if (!Redis::IsCommandExists(cmd)) {
-        return Status(Status::NotOK, "invalid command: "+cmd+" in profiling-sample-commands");
-      }
-      profiling_sample_commands.insert(cmd);
-    }
-  } else if (size == 2 && !strncasecmp(args[0].data(), "rocksdb.", 8)) {
-    return parseRocksdbOption(args[0].substr(8, args[0].size() - 8), args[1]);
-  } else if (size == 2 && !strncasecmp(args[0].data(), "namespace.", 10)) {
-    std::string ns = args[0].substr(10, args[0].size()-10);
-    auto s = isNamespaceLegal(ns);
-    if (!s.IsOK()) {
-      return s;
-    }
-    tokens[args[1]] = ns;
-  } else if (size == 2 && !strcasecmp(args[0].data(), "slowlog-log-slower-than")) {
-    slowlog_log_slower_than = std::atoll(args[1].c_str());
-  } else if (size == 2 && !strcasecmp(args[0].data(), "slowlog-max-len")) {
-    slowlog_max_len = std::atoi(args[1].c_str());
-  } else if (size == 2 && args[0] == "supervised") {
-    supervised_mode = configEnumGetValue(supervised_mode_enum, args[1].c_str());
-    if (supervised_mode == INT_MIN) {
-      return Status(Status::NotOK, "Invalid option for 'supervised'."
-                                   " Allowed values: 'upstart', 'systemd', 'auto', 'no'");
-    }
-  } else {
-    return Status(Status::NotOK, "Bad directive or wrong number of arguments");
+  }
+  if (!strncasecmp(kv[0].data(), "namespace.", 10)) {
+    tokens[kv[1]] = kv[0].substr(10, kv[0].size()-10);
+  }
+  return Status::OK();
+}
+
+Status Config::finish() {
+  if (requirepass.empty() && !tokens.empty()) {
+    return Status(Status::NotOK, "requirepass empty wasn't allowed while the namespace exists");
+  }
+  if (codis_enabled && !tokens.empty()) {
+    return Status(Status::NotOK, "enabled codis wasn't allowed while the namespace exists");
+  }
+  if (db_dir.empty()) db_dir = dir + "/db";
+  if (backup_dir.empty()) backup_dir = dir + "/backup";
+  if (pidfile.empty()) pidfile = dir + "/kvrocks.pid";
+  std::vector<std::string> createDirs = {dir, backup_dir};
+  for (const auto &name : createDirs) {
+    auto s = rocksdb::Env::Default()->CreateDirIfMissing(name);
+    if (!s.ok()) return Status(Status::NotOK, s.ToString());
   }
   return Status::OK();
 }
@@ -316,9 +348,7 @@ Status Config::parseConfigFromString(std::string input) {
 Status Config::Load(std::string path) {
   path_ = std::move(path);
   std::ifstream file(path_);
-  if (!file.is_open()) {
-    return Status(Status::NotOK, strerror(errno));
-  }
+  if (!file.is_open()) return Status(Status::NotOK, strerror(errno));
 
   std::string line;
   int line_num = 1;
@@ -331,426 +361,104 @@ Status Config::Load(std::string path) {
     }
     line_num++;
   }
-  if (backup_dir.empty()) {  // backup-dir was not assigned in config file
-    backup_dir = dir+"/backup";
-  }
-  if (!tokens.empty()) {
-    if (requirepass.empty()) {
-      file.close();
-      return Status(Status::NotOK, "requirepass was required when namespace isn't empty");
-    }
-    if (codis_enabled) {
-      file.close();
-      return Status(Status::NotOK, "namespace wasn't allowed when the codis mode enabled");
-    }
-  }
-  auto s = rocksdb::Env::Default()->CreateDirIfMissing(dir);
-  if (!s.ok()) {
-    file.close();
-    return Status(Status::NotOK, s.ToString());
-  }
-  s = rocksdb::Env::Default()->CreateDirIfMissing(backup_dir);
-  if (!s.ok()) {
-    file.close();
-    return Status(Status::NotOK, s.ToString());
-  }
   file.close();
-  return Status::OK();
+  return finish();
 }
 
 void Config::Get(std::string key, std::vector<std::string> *values) {
-  key = Util::ToLower(key);
   values->clear();
-  bool is_all = key == "*";
-
-#define PUSH_IF_MATCH(name, value) do { \
-  if ((is_all) || (key) == (name)) { \
-    values->emplace_back((name)); \
-    values->emplace_back((value)); \
-  } \
-} while (0);
-
-  std::string master_str;
-  if (!master_host.empty()) {
-    master_str = master_host+" "+ std::to_string(master_port);
-  }
-  std::string binds_str;
-  array2String(binds, ",", &binds_str);
-  std::string sample_commands_str;
-  if (profiling_sample_all_commands) {
-    sample_commands_str = "*";
-  } else {
-    for (const auto &cmd : profiling_sample_commands) {
-      sample_commands_str.append(cmd);
-      sample_commands_str.append(",");
-    }
-    if (!sample_commands_str.empty()) sample_commands_str.pop_back();
-  }
-  PUSH_IF_MATCH("dir", dir);
-  PUSH_IF_MATCH("db-dir", db_dir);
-  PUSH_IF_MATCH("backup-dir", backup_dir);
-  PUSH_IF_MATCH("port", std::to_string(port));
-  PUSH_IF_MATCH("workers", std::to_string(workers));
-  PUSH_IF_MATCH("timeout", std::to_string(timeout));
-  PUSH_IF_MATCH("tcp-backlog", std::to_string(backlog));
-  PUSH_IF_MATCH("daemonize", (daemonize ? "yes" : "no"));
-  PUSH_IF_MATCH("supervised", configEnumGetName(supervised_mode_enum, supervised_mode));
-  PUSH_IF_MATCH("maxclients", std::to_string(maxclients));
-  PUSH_IF_MATCH("slave-read-only", (slave_readonly ? "yes" : "no"));
-  PUSH_IF_MATCH("slave-serve-stale-data", (slave_serve_stale_data ? "yes" : "no"));
-  PUSH_IF_MATCH("slave-priority", std::to_string(slave_priority));
-  PUSH_IF_MATCH("max-backup-to-keep", std::to_string(max_backup_to_keep));
-  PUSH_IF_MATCH("max-backup-keep-hours", std::to_string(max_backup_keep_hours));
-  PUSH_IF_MATCH("codis-enabled", (codis_enabled ? "yes" : "no"));
-  PUSH_IF_MATCH("compact-cron", compact_cron.ToString());
-  PUSH_IF_MATCH("bgsave-cron", bgsave_cron.ToString());
-  PUSH_IF_MATCH("loglevel", kLogLevels[loglevel]);
-  PUSH_IF_MATCH("requirepass", requirepass);
-  PUSH_IF_MATCH("masterauth", masterauth);
-  PUSH_IF_MATCH("slaveof", master_str);
-  PUSH_IF_MATCH("pidfile", pidfile);
-  PUSH_IF_MATCH("db-name", db_name);
-  PUSH_IF_MATCH("binds", binds_str);
-  PUSH_IF_MATCH("max-io-mb", std::to_string(max_io_mb));
-  PUSH_IF_MATCH("max-db-size", std::to_string(max_db_size));
-  PUSH_IF_MATCH("slowlog-max-len", std::to_string(slowlog_max_len));
-  PUSH_IF_MATCH("max-replication-mb", std::to_string(max_replication_mb));
-  PUSH_IF_MATCH("profiling-sample-commands", sample_commands_str);
-  PUSH_IF_MATCH("profiling-sample-ratio", std::to_string(profiling_sample_ratio));
-  PUSH_IF_MATCH("profiling-sample-record-max-len", std::to_string(profiling_sample_record_max_len));
-  PUSH_IF_MATCH("profiling-sample-record-threshold-ms", std::to_string(profiling_sample_record_threshold_ms));
-  PUSH_IF_MATCH("slowlog-log-slower-than", std::to_string(slowlog_log_slower_than));
-  PUSH_IF_MATCH("rocksdb.max_open_files", std::to_string(rocksdb_options.max_open_files));
-  PUSH_IF_MATCH("rocksdb.block_size", std::to_string(rocksdb_options.block_size));
-  PUSH_IF_MATCH("rocksdb.write_buffer_size", std::to_string(rocksdb_options.write_buffer_size/MiB));
-  PUSH_IF_MATCH("rocksdb.max_write_buffer_number", std::to_string(rocksdb_options.max_write_buffer_number));
-  PUSH_IF_MATCH("rocksdb.max_background_compactions", std::to_string(rocksdb_options.max_background_compactions));
-  PUSH_IF_MATCH("rocksdb.metadata_block_cache_size", std::to_string(rocksdb_options.metadata_block_cache_size/MiB));
-  PUSH_IF_MATCH("rocksdb.subkey_block_cache_size", std::to_string(rocksdb_options.subkey_block_cache_size/MiB));
-  PUSH_IF_MATCH("rocksdb.compaction_readahead_size", std::to_string(rocksdb_options.compaction_readahead_size));
-  PUSH_IF_MATCH("rocksdb.max_background_flushes", std::to_string(rocksdb_options.max_background_flushes));
-  PUSH_IF_MATCH("rocksdb.enable_pipelined_write", (rocksdb_options.enable_pipelined_write ? "yes": "no"))
-  PUSH_IF_MATCH("rocksdb.cache_index_and_filter_blocks", (rocksdb_options.cache_index_and_filter_blocks? "yes": "no"))
-  PUSH_IF_MATCH("rocksdb.stats_dump_period_sec", std::to_string(rocksdb_options.stats_dump_period_sec));
-  PUSH_IF_MATCH("rocksdb.max_sub_compactions", std::to_string(rocksdb_options.max_sub_compactions));
-  PUSH_IF_MATCH("rocksdb.delayed_write_rate", std::to_string(rocksdb_options.delayed_write_rate));
-  PUSH_IF_MATCH("rocksdb.wal_ttl_seconds", std::to_string(rocksdb_options.WAL_ttl_seconds));
-  PUSH_IF_MATCH("rocksdb.wal_size_limit_mb", std::to_string(rocksdb_options.WAL_size_limit_MB));
-  PUSH_IF_MATCH("rocksdb.target_file_size_base", std::to_string(rocksdb_options.target_file_size_base));
-  PUSH_IF_MATCH("rocksdb.level0_slowdown_writes_trigger",
-                std::to_string(rocksdb_options.level0_slowdown_writes_trigger));
-  PUSH_IF_MATCH("rocksdb.level0_stop_writes_trigger", std::to_string(rocksdb_options.level0_stop_writes_trigger));
-  PUSH_IF_MATCH("rocksdb.compression", kCompressionType[rocksdb_options.compression]);
-}
-
-Status Config::setRocksdbOption(Engine::Storage *storage, const std::string &key, const std::string &value) {
-  int64_t i;
-  bool is_cf_mutal_option = false;
-  auto db = storage->GetDB();
-  auto s = Util::StringToNum(value, &i, 0);
-  if (!s.IsOK()) return s;
-  if (key == "stats_dump_period_sec") {
-    rocksdb_options.stats_dump_period_sec = static_cast<int>(i);
-  } else if (key == "max_open_files") {
-    rocksdb_options.max_open_files = static_cast<int>(i);
-  } else if (key == "delayed_write_rate") {
-    rocksdb_options.delayed_write_rate = static_cast<uint64_t>(i);
-  } else if (key == "max_background_compactions") {
-    rocksdb_options.max_background_compactions = static_cast<int>(i);
-  } else if (key == "max_background_flushes") {
-    rocksdb_options.max_background_flushes = static_cast<int>(i);
-  } else if (key == "compaction_readahead_size") {
-    rocksdb_options.compaction_readahead_size = static_cast<size_t>(i);
-  } else if (key == "target_file_size_base") {
-    is_cf_mutal_option = true;
-    rocksdb_options.target_file_size_base = static_cast<uint64_t>(i);
-  } else if (key == "write_buffer_size") {
-    is_cf_mutal_option = true;
-    rocksdb_options.write_buffer_size = static_cast<uint64_t>(i*MiB);
-  } else if (key == "max_write_buffer_number") {
-    is_cf_mutal_option = true;
-    rocksdb_options.max_write_buffer_number =  static_cast<int>(i);
-  } else if (key == "level0_slowdown_writes_trigger") {
-    is_cf_mutal_option = true;
-    rocksdb_options.level0_slowdown_writes_trigger = static_cast<int>(i);
-    rocksdb_options.level0_stop_writes_trigger = static_cast<int>(i * 2);
-  } else {
-    return Status(Status::NotOK, "option can't be set in-flight");
-  }
-  rocksdb::Status r_status;
-  if (!is_cf_mutal_option) {
-    r_status = db->SetDBOptions({{key, value}});
-  } else {
-    auto cf_handles = storage->GetCFHandles();
-    for (auto & cf_handle : cf_handles) {
-      r_status = db->SetOptions(cf_handle, {{key, value}});
-      if (!r_status.ok()) break;
+  for (const auto &iter : fields_) {
+    if (key == "*" || Util::ToLower(key) == iter.first) {
+      values->emplace_back(iter.first);
+      values->emplace_back(iter.second->ToString());
     }
   }
-  if (r_status.ok()) return Status::OK();
-  return Status(Status::NotOK, r_status.ToString());
 }
 
-Status Config::Set(std::string key, const std::string &value, Server *svr) {
+Status Config::Set(Server *svr, std::string key, const std::string &value) {
   key = Util::ToLower(key);
-  if (key == "timeout") {
-    timeout = std::atoi(value.c_str());
-    return Status::OK();
+  auto iter = fields_.find(key);
+  if (iter == fields_.end() || iter->second->readonly) {
+    return Status(Status::NotOK, "Unsupported CONFIG parameter: "+key);
   }
-  if (key == "backup-dir") {
-    auto s = rocksdb::Env::Default()->CreateDirIfMissing(value);
-    if (!s.ok()) return Status(Status::NotOK, s.ToString());
-    backup_dir = value;
-    return Status::OK();
-  }
-  if (key == "maxclients") {
-    maxclients = std::atoi(value.c_str());
-    return Status::OK();
-  }
-  if (key == "max-backup-to-keep") {
-    max_backup_to_keep = static_cast<uint32_t>(std::atoi(value.c_str()));
-    return Status::OK();
-  }
-  if (key == "max-backup-keep-hours") {
-    max_backup_keep_hours = static_cast<uint32_t>(std::atoi(value.c_str()));
-    return Status::OK();
-  }
-  if (key == "masterauth") {
-    masterauth = value;
-    return Status::OK();
-  }
-  if (key == "requirepass") {
-    if (requirepass.empty() && !tokens.empty()) {
-      return Status(Status::NotOK, "don't clear the requirepass while the namespace wasn't empty");
-    }
-    requirepass = value;
-    return Status::OK();
-  }
-  if (key == "slave-read-only") {
-    int i;
-    if ((i = yesnotoi(value)) == -1) {
-      return Status(Status::NotOK, "argument must be 'yes' or 'no'");
-    }
-    slave_readonly = (i == 1);
-    return Status::OK();
-  }
-  if (key == "slave-serve-stale-data") {
-    int i;
-    if ((i = yesnotoi(value)) == -1) {
-      return Status(Status::NotOK, "argument must be 'yes' or 'no'");
-    }
-    slave_serve_stale_data = (i == 1);
-    return Status::OK();
-  }
-  if (key == "slave-priority") {
-    slave_priority = std::atoi(value.c_str());
-    return Status::OK();
-  }
-  if (key == "loglevel") {
-    for (size_t i = 0; i < kNumLogLevel; i++) {
-      if (Util::ToLower(value) == kLogLevels[i]) {
-        loglevel = static_cast<int>(i);
-        break;
-      }
-    }
-    return Status(Status::NotOK, "loglevel should be info,warning,error,fatal");
-  }
-  if (key == "compact-cron") {
-    std::vector<std::string> args;
-    Util::Split(value, " ", &args);
-    return compact_cron.SetScheduleTime(args);
-  }
-  if (key == "bgsave-cron") {
-    std::vector<std::string> args;
-    Util::Split(value, " ", &args);
-    return bgsave_cron.SetScheduleTime(args);
-  }
-  if (key == "slowlog-log-slower-than") {
-    slowlog_log_slower_than = std::atoll(value.c_str());
-    return Status::OK();
-  }
-  if (key == "slowlog-max-len") {
-    slowlog_max_len = std::atoi(value.c_str());
-    svr->GetSlowLog()->SetMaxEntries(slowlog_max_len);
-    return Status::OK();
-  }
-  if (key == "max-db-size") {
-    try {
-      int32_t i = std::atoi(value.c_str());
-      if (i < 0) {
-        return Status(Status::RedisParseErr, "value should be >= 0");
-      }
-      max_db_size = static_cast<uint32_t>(i);
-    } catch (std::exception &e) {
-      return Status(Status::RedisParseErr, "value is not an integer or out of range");
-    }
-    svr->storage_->CheckDBSizeLimit();
-    return Status::OK();
-  }
-  if (key == "max-replication-mb") {
-    int64_t i;
-    auto s = Util::StringToNum(value, &i, 0);
+  auto field = iter->second;
+  if (field->validate) {
+    auto s = field->validate(key, value);
     if (!s.IsOK()) return s;
-    svr->SetReplicationRateLimit(static_cast<uint64_t>(i));
-    return Status::OK();
   }
-  if (key == "max-io-mb") {
-    int64_t i;
-    auto s = Util::StringToNum(value, &i, 0);
-    if (!s.IsOK()) return s;
-    max_io_mb = i;
-    svr->storage_->SetIORateLimit(static_cast<uint64_t>(i));
-    return Status::OK();
+  auto s = field->Set(value);
+  if (!s.IsOK()) return s;
+  if (field->callback) {
+    return field->callback(svr, key, value);
   }
-  if (key == "profiling-sample-ratio") {
-    int64_t i;
-    auto s = Util::StringToNum(value, &i, 0, 100);
-    if (!s.IsOK()) return s;
-    profiling_sample_ratio = static_cast<int>(i);
-    return Status::OK();
-  }
-  if (key == "profiling-sample-record-threshold-ms") {
-    int64_t i;
-    auto s = Util::StringToNum(value, &i, 0, INT_MAX);
-    if (!s.IsOK()) return s;
-    profiling_sample_record_threshold_ms = static_cast<int>(i);
-    return Status::OK();
-  }
-  if (key == "profiling-sample-record-max-len") {
-    int64_t i;
-    auto s = Util::StringToNum(value, &i, 0, INT_MAX);
-    if (!s.IsOK()) return s;
-    profiling_sample_record_max_len = static_cast<int>(i);
-    svr->GetPerfLog()->SetMaxEntries(profiling_sample_record_max_len);
-    return Status::OK();
-  }
-  if (key == "profiling-sample-commands") {
-    std::vector<std::string> cmds;
-    Util::Split(value, ",", &cmds);
-    for (auto const &cmd : cmds) {
-      if (!Redis::IsCommandExists(cmd) && cmd != "*") {
-        return Status(Status::NotOK, "invalid command: "+cmd+" in profiling-sample-commands");
-      }
-    }
-    profiling_sample_all_commands = false;
-    profiling_sample_commands.clear();
-    for (auto const &cmd : cmds) {
-      if (cmd == "*") {
-        profiling_sample_all_commands = true;
-        profiling_sample_commands.clear();
-        break;
-      }
-      profiling_sample_commands.insert(cmd);
-    }
-    return Status::OK();
-  }
-  if (!strncasecmp(key.c_str(), "rocksdb.", 8)) {
-    return setRocksdbOption(svr->storage_, key.substr(8, key.size()-8), value);
-  }
-  return Status(Status::NotOK, "Unsupported CONFIG parameter");
+  return Status::OK();
 }
 
 Status Config::Rewrite() {
+  std::vector<std::string> lines;
+  std::map<std::string, std::string> new_config;
+  for (const auto &iter: fields_) {
+    new_config[iter.first] = iter.second->ToString();
+  }
+  for (const auto &iter: tokens) {
+    new_config["namespace." + iter.second] = iter.first;
+  }
+
+  std::ifstream file(path_);
+  if (file.is_open()) {
+    std::string raw_line, trim_line, new_value;
+    std::vector<std::string> kv;
+    while (!file.eof()) {
+      std::getline(file, raw_line);
+      Util::Trim(raw_line, " \t\r\n", &trim_line);
+      if (trim_line.empty() || trim_line.front() == '#') {
+        lines.emplace_back(raw_line);
+        continue;
+      }
+      Util::Split2KV(trim_line, " \t", &kv);
+      if (kv.size() != 2) {
+        lines.emplace_back(raw_line);
+        continue;
+      }
+      auto iter = new_config.find(Util::ToLower(kv[0]));
+      if (iter != new_config.end()) {
+        if (!iter->second.empty()) lines.emplace_back(iter->first + " " + iter->second);
+        new_config.erase(iter);
+      } else {
+        lines.emplace_back(raw_line);
+      }
+    }
+  }
+  file.close();
+
+  std::ostringstream string_stream;
+  for(const auto &line : lines) {
+    string_stream << line << "\n";
+  }
+  for (const auto &remain : new_config) {
+    if (remain.second.empty()) continue;
+    string_stream << remain.first << " " << remain.second << "\n";
+  }
   std::string tmp_path = path_+".tmp";
   remove(tmp_path.data());
   std::ofstream output_file(tmp_path, std::ios::out);
-
-  std::ostringstream string_stream;
-#define WRITE_TO_FILE(key, value) do { \
-  string_stream << (key) << " " << (value) <<  "\n"; \
-} while (0)
-
-  std::string binds_str, repl_binds_str, sample_commands_str;
-  array2String(binds, ",", &binds_str);
-  array2String(repl_binds, ",", &repl_binds_str);
-  if (profiling_sample_all_commands) {
-    sample_commands_str = "*";
-  } else {
-    for (const auto &cmd : profiling_sample_commands) {
-      sample_commands_str.append(cmd);
-      sample_commands_str.append(",");
-    }
-    if (!sample_commands_str.empty()) sample_commands_str.pop_back();
-  }
-  string_stream << "################################ GERNERAL #####################################\n";
-  WRITE_TO_FILE("bind", binds_str);
-  WRITE_TO_FILE("port", port);
-  WRITE_TO_FILE("repl-bind", repl_binds_str);
-  WRITE_TO_FILE("timeout", timeout);
-  WRITE_TO_FILE("workers", workers);
-  WRITE_TO_FILE("maxclients", maxclients);
-  WRITE_TO_FILE("repl-workers", repl_workers);
-  WRITE_TO_FILE("loglevel", kLogLevels[loglevel]);
-  WRITE_TO_FILE("daemonize", (daemonize?"yes":"no"));
-  WRITE_TO_FILE("supervised", (configEnumGetName(supervised_mode_enum, supervised_mode)));
-  WRITE_TO_FILE("db-name", db_name);
-  WRITE_TO_FILE("dir", dir);
-  WRITE_TO_FILE("backup-dir", backup_dir);
-  WRITE_TO_FILE("tcp-backlog", backlog);
-  WRITE_TO_FILE("slave-read-only", (slave_readonly? "yes":"no"));
-  WRITE_TO_FILE("slave-serve-stale-data", (slave_serve_stale_data? "yes":"no"));
-  WRITE_TO_FILE("slave-priority", slave_priority);
-  WRITE_TO_FILE("slowlog-max-len", slowlog_max_len);
-  WRITE_TO_FILE("slowlog-log-slower-than", slowlog_log_slower_than);
-  WRITE_TO_FILE("max-backup-to-keep", max_backup_to_keep);
-  WRITE_TO_FILE("max-backup-keep-hours", max_backup_keep_hours);
-  WRITE_TO_FILE("max-db-size", max_db_size);
-  WRITE_TO_FILE("max-replication-mb", max_replication_mb);
-  WRITE_TO_FILE("max-io-mb", max_io_mb);
-  WRITE_TO_FILE("codis-enabled", (codis_enabled? "yes":"no"));
-  if (!requirepass.empty()) WRITE_TO_FILE("requirepass", requirepass);
-  if (!masterauth.empty()) WRITE_TO_FILE("masterauth", masterauth);
-  if (!master_host.empty())  WRITE_TO_FILE("slaveof", master_host+" "+std::to_string(master_port));
-  if (compact_cron.IsEnabled()) WRITE_TO_FILE("compact-cron", compact_cron.ToString());
-  if (bgsave_cron.IsEnabled()) WRITE_TO_FILE("bgave-cron", bgsave_cron.ToString());
-  WRITE_TO_FILE("profiling-sample-ratio", profiling_sample_ratio);
-  if (!sample_commands_str.empty()) WRITE_TO_FILE("profiling-sample-commands", sample_commands_str);
-  WRITE_TO_FILE("profiling-sample-record-max-len", profiling_sample_record_max_len);
-  WRITE_TO_FILE("profiling-sample-record-threshold-ms", profiling_sample_record_threshold_ms);
-
-  string_stream << "\n################################ ROCKSDB #####################################\n";
-  WRITE_TO_FILE("rocksdb.max_open_files", rocksdb_options.max_open_files);
-  WRITE_TO_FILE("rocksdb.block_size", rocksdb_options.block_size);
-  WRITE_TO_FILE("rocksdb.write_buffer_size", rocksdb_options.write_buffer_size/MiB);
-  WRITE_TO_FILE("rocksdb.max_write_buffer_number", rocksdb_options.max_write_buffer_number);
-  WRITE_TO_FILE("rocksdb.max_background_compactions", rocksdb_options.max_background_compactions);
-  WRITE_TO_FILE("rocksdb.metadata_block_cache_size", rocksdb_options.metadata_block_cache_size/MiB);
-  WRITE_TO_FILE("rocksdb.subkey_block_cache_size", rocksdb_options.subkey_block_cache_size/MiB);
-  WRITE_TO_FILE("rocksdb.max_background_flushes", rocksdb_options.max_background_flushes);
-  WRITE_TO_FILE("rocksdb.max_sub_compactions", rocksdb_options.max_sub_compactions);
-  WRITE_TO_FILE("rocksdb.compression", kCompressionType[rocksdb_options.compression]);
-  WRITE_TO_FILE("rocksdb.enable_pipelined_write", (rocksdb_options.enable_pipelined_write ? "yes" : "no"));
-  WRITE_TO_FILE("rocksdb.cache_index_and_filter_blocks", (rocksdb_options.cache_index_and_filter_blocks? "yes" : "no"));
-  WRITE_TO_FILE("rocksdb.delayed_write_rate", rocksdb_options.delayed_write_rate);
-  WRITE_TO_FILE("rocksdb.compaction_readahead_size", rocksdb_options.compaction_readahead_size);
-  WRITE_TO_FILE("rocksdb.target_file_size_base", rocksdb_options.target_file_size_base);
-  WRITE_TO_FILE("rocksdb.level0_slowdown_writes_trigger", rocksdb_options.level0_slowdown_writes_trigger);
-  WRITE_TO_FILE("rocksdb.wal_ttl_seconds", rocksdb_options.WAL_ttl_seconds);
-  WRITE_TO_FILE("rocksdb.wal_size_limit_mb", rocksdb_options.WAL_size_limit_MB);
-
-  string_stream << "\n################################ Namespace #####################################\n";
-  for (const auto &iter : tokens) {
-    WRITE_TO_FILE("namespace."+iter.second, iter.first);
-  }
   output_file.write(string_stream.str().c_str(), string_stream.str().size());
   output_file.close();
   if (rename(tmp_path.data(), path_.data()) < 0) {
-    return Status(Status::NotOK, std::string("unable to rename config file, err: ")+strerror(errno));
+    return Status(Status::NotOK, std::string("rename file encounter error: ")+strerror(errno));
   }
   return Status::OK();
 }
 
 void Config::GetNamespace(const std::string &ns, std::string *token) {
   for (const auto &iter : tokens) {
-    if (iter.second == ns) {
-      *token = iter.first;
-    }
+    if (iter.second == ns) *token = iter.first;
   }
 }
 
 Status Config::SetNamespace(const std::string &ns, const std::string &token) {
   if (ns == kDefaultNamespace) {
-    return Status(Status::NotOK, "can't set the default namespace");
+    return Status(Status::NotOK, "forbidden to update the default namespace");
   }
   if (tokens.find(token) != tokens.end()) {
     return Status(Status::NotOK, "the token has already exists");
@@ -767,15 +475,13 @@ Status Config::SetNamespace(const std::string &ns, const std::string &token) {
 
 Status Config::AddNamespace(const std::string &ns, const std::string &token) {
   if (requirepass.empty()) {
-    return Status(Status::NotOK, "forbid to add new namespace while the requirepass is empty");
+    return Status(Status::NotOK, "forbidden to add namespace when requirepass was empty");
   }
   if (codis_enabled) {
-    return Status(Status::NotOK, "forbid to add new namespace while codis support is enabled");
+    return Status(Status::NotOK, "forbidden to add namespace when codis mode was enabled");
   }
   auto s = isNamespaceLegal(ns);
-  if (!s.IsOK()) {
-    return s;
-  }
+  if (!s.IsOK()) return s;
   if (tokens.find(token) != tokens.end()) {
     return Status(Status::NotOK, "the token has already exists");
   }
@@ -790,7 +496,7 @@ Status Config::AddNamespace(const std::string &ns, const std::string &token) {
 
 Status Config::DelNamespace(const std::string &ns) {
   if (ns == kDefaultNamespace) {
-    return Status(Status::NotOK, "can't del the default namespace");
+    return Status(Status::NotOK, "forbidden to delete the default namespace");
   }
   for (const auto &iter : tokens) {
     if (iter.second == ns) {
@@ -803,11 +509,11 @@ Status Config::DelNamespace(const std::string &ns) {
 
 Status Config::isNamespaceLegal(const std::string &ns) {
   if (ns.size() > UINT8_MAX) {
-    return Status(Status::NotOK, std::string("namespace size exceed limit ") + std::to_string(UINT8_MAX));
+    return Status(Status::NotOK, std::string("size exceed limit ") + std::to_string(UINT8_MAX));
   }
   char last_char = ns.back();
   if (last_char == std::numeric_limits<char>::max()) {
-    return Status(Status::NotOK, std::string("namespace contain ilegal letter"));
+    return Status(Status::NotOK, std::string("namespace contain illegal letter"));
   }
   return Status::OK();
 }

--- a/src/config.h
+++ b/src/config.h
@@ -8,6 +8,7 @@
 #include <vector>
 #include <set>
 
+#include "config_type.h"
 #include "status.h"
 #include "cron.h"
 
@@ -16,8 +17,6 @@ class Server;
 namespace Engine {
 class Storage;
 }
-
-extern const char *kDefaultNamespace;
 
 #define SUPERVISED_NONE 0
 #define SUPERVISED_AUTODETECT 1
@@ -28,38 +27,40 @@ const size_t KiB = 1024L;
 const size_t MiB = 1024L * KiB;
 const size_t GiB = 1024L * MiB;
 
+extern const char *kDefaultNamespace;
+
 struct Config{
  public:
-  int port = 6666;
-  int repl_port = port + 1;
-  int workers = 4;
-  int repl_workers = 1;
-  int timeout = 0;
-  int loglevel = 0;
-  int backlog = 1024;
-  int maxclients = 10240;
-  uint32_t max_backup_to_keep = 1;
-  uint32_t max_backup_keep_hours = 0;
-  int64_t slowlog_log_slower_than = 200000;  // 200ms
-  unsigned int slowlog_max_len = 0;
-  bool daemonize = false;
-  int supervised_mode = SUPERVISED_NONE;
-  bool slave_readonly = true;
-  bool slave_serve_stale_data = true;
-  uint32_t slave_priority = 100;
-  uint32_t max_db_size = 0;  // unit is GB
-  uint64_t max_replication_mb = 0;  // unit is MB
-  uint64_t max_io_mb = 500;  // unit is MB
-
-  bool codis_enabled = false;
-
-  std::vector<std::string> binds{"127.0.0.1"};
-  std::vector<std::string> repl_binds{"127.0.0.1"};
-  std::string dir = "/tmp/ev";
-  std::string db_dir = dir+"/db";
+  Config();
+  ~Config();
+  int port;
+  int repl_port;
+  int workers;
+  int repl_workers;
+  int timeout;
+  int loglevel;
+  int backlog;
+  int maxclients;
+  int max_backup_to_keep;
+  int max_backup_keep_hours;
+  int slowlog_log_slower_than;
+  int slowlog_max_len;
+  bool daemonize;
+  int supervised_mode;
+  bool slave_readonly;
+  bool slave_serve_stale_data;
+  int slave_priority;
+  int max_db_size;
+  int max_replication_mb;
+  int max_io_mb;
+  bool codis_enabled;
+  std::vector<std::string> binds;
+  std::vector<std::string> repl_binds;
+  std::string dir;
+  std::string db_dir;
   std::string backup_dir;
-  std::string pidfile = dir+"/kvrocks.pid";
-  std::string db_name = "changeme.name";
+  std::string pidfile;
+  std::string db_name;
   std::string masterauth;
   std::string requirepass;
   std::string master_host;
@@ -69,55 +70,60 @@ struct Config{
   std::map<std::string, std::string> tokens;
 
   // profiling
-  int profiling_sample_ratio = 0;
-  int profiling_sample_record_threshold_ms = 0;
-  int profiling_sample_record_max_len = 256;
+  int profiling_sample_ratio;
+  int profiling_sample_record_threshold_ms;
+  int profiling_sample_record_max_len;
   std::set<std::string> profiling_sample_commands;
   bool profiling_sample_all_commands = false;
 
   struct {
-    size_t block_size = 4096;
-    bool cache_index_and_filter_blocks = false;
-    size_t metadata_block_cache_size = 2 * GiB;
-    size_t subkey_block_cache_size = 2 * GiB;
-    int max_open_files = 4096;
-    uint64_t write_buffer_size = 64 * MiB;
-    int max_write_buffer_number = 4;
-    int max_background_compactions = 2;
-    int max_background_flushes = 2;
-    uint32_t max_sub_compactions = 1;
-    rocksdb::CompressionType compression = rocksdb::kSnappyCompression;  // default: snappy
-    int stats_dump_period_sec = 0;
-    bool enable_pipelined_write = true;
-    uint64_t delayed_write_rate = 0;
-    size_t compaction_readahead_size = 2 * MiB;
-    uint64_t target_file_size_base = 256 * MiB;
-    uint64_t WAL_ttl_seconds = 7 * 24 * 3600;
-    uint64_t WAL_size_limit_MB = 5 * 1024;
-    int level0_slowdown_writes_trigger = 20;
-    int level0_stop_writes_trigger = 36;
-  } rocksdb_options;
+    int block_size;
+    bool cache_index_and_filter_blocks;
+    int metadata_block_cache_size;
+    int subkey_block_cache_size;
+    int max_open_files;
+    int write_buffer_size;
+    int max_write_buffer_number;
+    int max_background_compactions;
+    int max_background_flushes;
+    int max_sub_compactions;
+    int stats_dump_period_sec;
+    bool enable_pipelined_write;
+    int64_t delayed_write_rate;
+    int compaction_readahead_size;
+    int target_file_size_base;
+    int WAL_ttl_seconds;
+    int WAL_size_limit_MB;
+    int level0_slowdown_writes_trigger;
+    int level0_stop_writes_trigger;
+    int compression;
+  } RocksDB;
 
  public:
   Status Rewrite();
   Status Load(std::string path);
   void Get(std::string key, std::vector<std::string> *values);
-  Status Set(std::string key, const std::string &value, Server *svr);
-  Status setRocksdbOption(Engine::Storage *storage, const std::string &key, const std::string &value);
+  Status Set(Server *svr, std::string key, const std::string &value);
+  void SetMaster(const std::string &host, int port);
+  void ClearMaster();
   void GetNamespace(const std::string &ns, std::string *token);
   Status AddNamespace(const std::string &ns, const std::string &token);
   Status SetNamespace(const std::string &ns, const std::string &token);
   Status DelNamespace(const std::string &ns);
-  Config() = default;
-  ~Config() = default;
 
  private:
   std::string path_;
-  int yesnotoi(std::string input);
-  void incrOpenFilesLimit(rlim_t maxfiles);
+  std::string binds_;
+  std::string repl_binds_;
+  std::string slaveof_;
+  std::string compact_cron_;
+  std::string bgsave_cron_;
+  std::string profiling_sample_commands_;
+  std::map<std::string, ConfigField*> fields_;
+
+  void initFieldValidator();
+  void initFieldCallback();
   Status parseConfigFromString(std::string input);
-  Status parseRocksdbOption(const std::string &key, std::string value);
-  Status parseRocksdbIntOption(std::string key, std::string value);
-  void array2String(const std::vector<std::string> &array, const std::string &delim, std::string *output);
+  Status finish();
   Status isNamespaceLegal(const std::string &ns);
 };

--- a/src/config_type.h
+++ b/src/config_type.h
@@ -1,0 +1,159 @@
+#ifndef KVROCKS_CONFIG_TYPE_H
+#define KVROCKS_CONFIG_TYPE_H
+
+#include "util.h"
+#include "status.h"
+
+// forward declaration
+class Server;
+
+typedef std::function<Status(const std::string&, const std::string&)> validate_fn;
+typedef std::function<Status(Server *srv, const std::string&, const std::string&)> callback_fn;
+
+typedef struct configEnum {
+  const char *name;
+  const int val;
+} configEnum;
+int configEnumGetValue(configEnum *ce, const char *name);
+const char *configEnumGetName(configEnum *ce, int val);
+
+class ConfigField {
+ public:
+  ConfigField() = default;
+  virtual ~ConfigField() = 0;
+  virtual std::string ToString() = 0;
+  virtual Status Set(const std::string &v) = 0;
+  virtual Status ToNumber(int64_t *n) { return Status(Status::NotOK, "not supported"); }
+  virtual Status ToBool(bool *b) { return Status(Status::NotOK, "not supported"); }
+
+ public:
+  bool readonly = true;
+  validate_fn validate = nullptr;
+  callback_fn callback = nullptr ;
+};
+
+class StringField: public ConfigField {
+ public:
+  StringField(std::string *receiver, std::string s): receiver_(receiver) {
+    *receiver_ = std::move(s);
+  }
+  ~StringField() override = default;
+  std::string ToString() override {
+    return *receiver_;
+  }
+  Status Set(const std::string &v) override {
+    *receiver_ = v;
+    return Status::OK();
+  }
+ private:
+  std::string *receiver_;
+};
+
+class IntField : public ConfigField {
+ public:
+  IntField(int *receiver, int n, int min, int max)
+      : receiver_(receiver), min_(min), max_(max) {
+    *receiver_ = n;
+  }
+  ~IntField() override = default;
+  std::string ToString() override {
+    return std::to_string(*receiver_);
+  }
+  Status ToNumber(int64_t *n) override {
+    *n = *receiver_;
+    return Status::OK();
+  }
+  Status Set(const std::string &v) override {
+    int64_t n;
+    auto s = Util::StringToNum(v, &n, min_, max_);
+    if (!s.IsOK()) return s;
+    *receiver_ = static_cast<int>(n);
+    return Status::OK();
+  }
+ private:
+  int *receiver_;
+  int min_ = INT_MIN;
+  int max_ = INT_MAX;
+};
+
+class Int64Field : public ConfigField {
+ public:
+  Int64Field(int64_t *receiver, int64_t n, int64_t min, int64_t max)
+      : receiver_(receiver), min_(min), max_(max) {
+    *receiver_ = n;
+  }
+  ~Int64Field() override = default;
+  std::string ToString() override {
+    return std::to_string(*receiver_);
+  }
+  Status ToNumber(int64_t *n) override {
+    *n = *receiver_;
+    return Status::OK();
+  }
+  Status Set(const std::string &v) override {
+    int64_t n;
+    auto s = Util::StringToNum(v, &n, min_, max_);
+    if (!s.IsOK()) return s;
+    *receiver_ = n;
+    return Status::OK();
+  }
+ private:
+  int64_t *receiver_;
+  int64_t min_ = INT64_MIN;
+  int64_t max_ = INT64_MAX;
+};
+
+class YesNoField : public ConfigField {
+ public:
+  YesNoField(bool *receiver, bool b) : receiver_(receiver) {
+    *receiver_ = b;
+  }
+  ~YesNoField() override = default;
+  std::string ToString() override {
+    return *receiver_ ? "yes":"no" ;
+  }
+  Status ToBool(bool *b) override {
+    *b = *receiver_;
+    return Status::OK();
+  }
+  Status Set(const std::string &v) override {
+    if (strcasecmp(v.data(), "yes") == 0) {
+      *receiver_ = true;
+    } else if (strcasecmp(v.data(), "no") == 0) {
+      *receiver_ = false;
+    } else {
+      return Status(Status::NotOK, "argument must be 'yes' or 'no'");
+    }
+    return Status::OK();
+  }
+ private:
+  bool *receiver_;
+};
+
+class EnumField : public ConfigField {
+ public:
+  EnumField(int *receiver, configEnum *enums, int e) :
+      receiver_(receiver), enums_(enums) {
+    *receiver_ = e;
+  }
+  ~EnumField() override = default;
+  std::string ToString() override {
+    return configEnumGetName(enums_, *receiver_);
+  }
+  Status ToNumber(int64_t *n) override {
+    *n = *receiver_;
+    return Status::OK();
+  }
+  Status Set(const std::string &v) override {
+    int e = configEnumGetValue(enums_, v.c_str());
+    if (e == INT_MIN) {
+      return Status(Status::NotOK, "invaild enum option");
+    }
+    *receiver_ = e;
+    return Status::OK();
+  }
+ private:
+  int *receiver_;
+  configEnum *enums_ = nullptr;
+};
+#endif //KVROCKS_CONFIG_TYPE_H

--- a/src/redis_cmd.cc
+++ b/src/redis_cmd.cc
@@ -209,7 +209,7 @@ class CommandConfig : public Commander {
     } else if (args_.size() == 4 && sub_command == "set") {
       Status s = config->Set(svr, args_[2], args_[3]);
       if (!s.IsOK()) {
-        *output = Redis::Error("ERR "+s.Msg());
+        *output = Redis::Error("CONFIG SET '"+args_[2]+"' error: "+s.Msg());
       } else {
         *output = Redis::SimpleString("OK");
       }

--- a/src/redis_cmd.cc
+++ b/src/redis_cmd.cc
@@ -201,9 +201,9 @@ class CommandConfig : public Commander {
       config->Get(args_[2], &values);
       *output = Redis::MultiBulkString(values);
     } else if (args_.size() == 4 && Util::ToLower(args_[1]) == "set") {
-      Status s = config->Set(args_[2], args_[3], svr);
+      Status s = config->Set(svr, args_[2], args_[3]);
       if (!s.IsOK()) {
-        return Status(Status::NotOK, s.Msg() + ", key: " + args_[2]);
+        return Status(Status::NotOK, "config set '" + args_[2]+"' error: "+s.Msg());
       }
       *output = Redis::SimpleString("OK");
     } else {

--- a/src/redis_cmd.cc
+++ b/src/redis_cmd.cc
@@ -189,23 +189,30 @@ class CommandConfig : public Commander {
       *output = Redis::Error("only administrator can use config command");
       return Status::OK();
     }
-
     Config *config = svr->GetConfig();
-    if (args_.size() == 2 && Util::ToLower(args_[1]) == "rewrite") {
+    std::string sub_command = Util::ToLower(args_[1]);
+    if ((sub_command == "rewrite" && args_.size() != 2) ||
+        (sub_command == "get" && args_.size() != 3) ||
+        (sub_command == "set" && args_.size() != 4)) {
+      *output = Redis::Error("ERR wrong number of arguments");
+      return Status::OK();
+    }
+    if (args_.size() == 2 && sub_command == "rewrite") {
       Status s = config->Rewrite();
       if (!s.IsOK()) return Status(Status::RedisExecErr, s.Msg());
       *output = Redis::SimpleString("OK");
       LOG(INFO) << "# CONFIG REWRITE executed with success";
-    } else if (args_.size() == 3 && Util::ToLower(args_[1]) == "get") {
+    } else if (args_.size() == 3 && sub_command == "get") {
       std::vector<std::string> values;
       config->Get(args_[2], &values);
       *output = Redis::MultiBulkString(values);
-    } else if (args_.size() == 4 && Util::ToLower(args_[1]) == "set") {
+    } else if (args_.size() == 4 && sub_command == "set") {
       Status s = config->Set(svr, args_[2], args_[3]);
       if (!s.IsOK()) {
-        return Status(Status::NotOK, "config set '" + args_[2]+"' error: "+s.Msg());
+        *output = Redis::Error("ERR "+s.Msg());
+      } else {
+        *output = Redis::SimpleString("OK");
       }
-      *output = Redis::SimpleString("OK");
     } else {
       *output = Redis::Error("CONFIG subcommand must be one of GET, SET, REWRITE");
     }

--- a/src/redis_request.cc
+++ b/src/redis_request.cc
@@ -200,8 +200,8 @@ void Request::ExecuteCommands(Connection *conn) {
     svr_->FeedMonitorConns(conn, cmd_tokens);
     if (!s.IsOK()) {
       conn->Reply(Redis::Error("ERR " + s.Msg()));
-      LOG(ERROR) << "[request] Failed to execute command: " << cmd_name
-                 << ", encounter err: " << s.Msg();
+      LOG(ERROR) << "[request] Encounter error when excuting '" << cmd_name
+                 << "' command, " << s.Msg();
       continue;
     }
     if (!reply.empty()) conn->Reply(reply);

--- a/src/server.cc
+++ b/src/server.cc
@@ -125,8 +125,7 @@ Status Server::AddMaster(std::string host, uint32_t port) {
   if (s.IsOK()) {
     master_host_ = host;
     master_port_ = port;
-    config_->master_host = host;
-    config_->master_port = port;
+    config_->SetMaster(host, port);
   } else {
     replication_thread_ = nullptr;
   }
@@ -139,8 +138,7 @@ Status Server::RemoveMaster() {
   if (!master_host_.empty()) {
     master_host_.clear();
     master_port_ = 0;
-    config_->master_host.clear();
-    config_->master_port = 0;
+    config_->ClearMaster();
     if (replication_thread_) replication_thread_->Stop();
     replication_thread_ = nullptr;
   }

--- a/src/storage.h
+++ b/src/storage.h
@@ -34,6 +34,8 @@ class Storage {
   Status OpenForReadOnly();
   void CloseDB();
   void InitOptions(rocksdb::Options *options);
+  Status SetColumnFamilyOption(const std::string &key, const std::string &value);
+  Status SetDBOption(const std::string &key, const std::string &value);
   Status CreateColumnFamiles(const rocksdb::Options &options);
   Status CreateBackup();
   Status DestroyBackup();

--- a/src/util.cc
+++ b/src/util.cc
@@ -203,6 +203,26 @@ void Split(std::string in, std::string delim, std::vector<std::string> *out) {
   } while (pos != std::string::npos);
 }
 
+void Split2KV(const std::string&in, std::string delim, std::vector<std::string> *out) {
+  out->clear();
+  std::string::size_type pos;
+  if ((pos = in.find_first_of(delim)) != std::string::npos) {
+    pos = in.find_first_of(delim);
+    std::string str, key, value;
+    str = in.substr(0, pos);
+    Util::Trim(str, delim, &key);
+    if (!key.empty()) out->push_back(key);
+    str = in.substr(pos+1);
+    Util::Trim(str, delim, &value);
+    if (!value.empty()) out->push_back(value);
+  }
+}
+
+bool HasPrefix(const std::string &str, const std::string &prefix) {
+  if (str.empty() || prefix.empty()) return false;
+  return !strncasecmp(str.data(), prefix.data(), prefix.size());
+}
+
 int StringMatch(const std::string &pattern, const std::string &in, int nocase) {
   return StringMatchLen(pattern.c_str(), pattern.length(), in.c_str(), in.length(), nocase);
 }

--- a/src/util.h
+++ b/src/util.h
@@ -26,6 +26,8 @@ std::string ToLower(std::string in);
 void BytesToHuman(char *buf, size_t size, uint64_t n);
 void Trim(const std::string &in, const std::string &chars, std::string *out);
 void Split(std::string in, std::string delim, std::vector<std::string> *out);
+void Split2KV(const std::string&in, std::string delim, std::vector<std::string> *out);
+bool HasPrefix(const std::string &str, const std::string &prefix);
 int StringMatch(const std::string &pattern, const std::string &in, int nocase);
 int StringMatchLen(const char *p, int plen, const char *s, int slen, int nocase);
 

--- a/tests/config_test.cc
+++ b/tests/config_test.cc
@@ -4,36 +4,94 @@
 #include <vector>
 #include <gtest/gtest.h>
 
-TEST(Config, Profiling) {
+TEST(Config, GetAndSet) {
   const char *path = "test.conf";
   Config config;
-  Server srv(nullptr, &config);
 
   config.Load(path);
-  std::map<std::string, std::string> cases = {
+  std::map<std::string, std::string> mutable_cases = {
+      {"timeout" , "1000"},
+      {"maxclients" , "2000"},
+      {"max-backup-to-keep" , "32"},
+      {"max-backup-keep-hours" , "4000"},
+      {"requirepass" , "mytest_requirepass"},
+      {"masterauth" , "mytest_masterauth"},
+      {"compact-cron" , "1 2 3 4 5"},
+      {"bgsave-cron" , "5 4 3 2 1"},
+      {"max-io-mb" , "5000"},
+      {"max-db-size" , "6000"},
+      {"max-replication-mb" , "7000"},
+      {"slave-serve-stale-data" , "no"},
+      {"slave-read-only" , "no"},
+      {"slave-priority" , "101"},
+      {"slowlog-log-slower-than" , "1234"},
+      {"slowlog-max-len" , "123"},
       {"profiling-sample-ratio" , "50"},
       {"profiling-sample-record-max-len" , "1"},
       {"profiling-sample-record-threshold-ms" , "50"},
       {"profiling-sample-commands" , "get,set"},
+
+      {"rocksdb.compression" , "no"},
+      {"rocksdb.max_open_files" , "1234"},
+      {"rocksdb.write_buffer_size" , "1234"},
+      {"rocksdb.max_write_buffer_number" , "1"},
+      {"rocksdb.max_background_compactions" , "2"},
+      {"rocksdb.max_sub_compactions" , "3"},
+      {"rocksdb.delayed_write_rate" , "1234"},
+      {"rocksdb.stats_dump_period_sec" , "600"},
+      {"rocksdb.compaction_readahead_size" , "1024"},
+      {"rocksdb.level0_slowdown_writes_trigger" , "50"},
   };
   std::vector<std::string> values;
-  for (const auto &iter : cases) {
-    config.Set(&srv, iter.first, iter.second);
+  for (const auto &iter : mutable_cases) {
+    auto s = config.Set(nullptr, iter.first, iter.second);
+    ASSERT_TRUE(s.IsOK());
     config.Get(iter.first, &values);
+    ASSERT_TRUE(s.IsOK());
     ASSERT_EQ(values.size(), 2);
     EXPECT_EQ(values[0], iter.first);
     EXPECT_EQ(values[1], iter.second);
   }
   ASSERT_TRUE(config.Rewrite().IsOK());
   config.Load(path);
-  for (const auto &iter : cases) {
-    config.Set(&srv, iter.first, iter.second);
+  for (const auto &iter : mutable_cases) {
+    auto s = config.Set(nullptr, iter.first, iter.second);
+    ASSERT_TRUE(s.IsOK());
     config.Get(iter.first, &values);
     ASSERT_EQ(values.size(), 2);
     EXPECT_EQ(values[0], iter.first);
     EXPECT_EQ(values[1], iter.second);
   }
   unlink(path);
+
+  std::map<std::string, std::string> immutable_cases = {
+      {"daemonize", "yes"},
+      {"bind", "0.0.0.0"},
+      {"repl-bind", "0.0.0.0"},
+      {"workers", "8"},
+      {"repl-workers", "8"},
+      {"tcp-backlog", "500"},
+      {"codis-enabled", "yes"},
+      {"slaveof", "no one"},
+      {"db-name", "test_dbname"},
+      {"dir", "test_dir"},
+      {"backup-dir", "test_dir/backup"},
+      {"pidfile", "test.pid"},
+      {"supervised", "no"},
+      {"rocksdb.block_size", "1234"},
+      {"rocksdb.target_file_size_base", "100"},
+      {"rocksdb.max_background_flushes", "16"},
+      {"rocksdb.wal_ttl_seconds", "10000"},
+      {"rocksdb.wal_size_limit_mb", "16"},
+      {"rocksdb.enable_pipelined_write", "no"},
+      {"rocksdb.cache_index_and_filter_blocks", "no"},
+      {"rocksdb.metadata_block_cache_size", "100"},
+      {"rocksdb.subkey_block_cache_size", "100"},
+  };
+  for (const auto &iter : immutable_cases) {
+    auto s = config.Set(nullptr, iter.first, iter.second);
+    ASSERT_FALSE(s.IsOK());
+  }
 }
 
 TEST(Namespace, Add) {

--- a/tests/config_test.cc
+++ b/tests/config_test.cc
@@ -18,7 +18,7 @@ TEST(Config, Profiling) {
   };
   std::vector<std::string> values;
   for (const auto &iter : cases) {
-    config.Set(iter.first, iter.second, &srv);
+    config.Set(&srv, iter.first, iter.second);
     config.Get(iter.first, &values);
     ASSERT_EQ(values.size(), 2);
     EXPECT_EQ(values[0], iter.first);
@@ -27,7 +27,7 @@ TEST(Config, Profiling) {
   ASSERT_TRUE(config.Rewrite().IsOK());
   config.Load(path);
   for (const auto &iter : cases) {
-    config.Set(iter.first, iter.second, &srv);
+    config.Set(&srv, iter.first, iter.second);
     config.Get(iter.first, &values);
     ASSERT_EQ(values.size(), 2);
     EXPECT_EQ(values[0], iter.first);
@@ -122,10 +122,11 @@ TEST(Namespace, RewriteNamespaces) {
   for(size_t i = 0; i < namespaces.size(); i++) {
     EXPECT_TRUE(config.AddNamespace(namespaces[i], tokens[i]).IsOK());
   }
-  EXPECT_TRUE(config.Rewrite().IsOK());
-  Config new_config;
-  auto s = new_config.Load(path) ;
+  auto s = config.Rewrite();
   std::cout << s.Msg() << std::endl;
+  EXPECT_TRUE(s.IsOK());
+  Config new_config;
+  s = new_config.Load(path) ;
   for(size_t i = 0; i < namespaces.size(); i++) {
     std::string token;
     new_config.GetNamespace(namespaces[i], &token);


### PR DESCRIPTION
This's a huge PR and not easy to review, but its goal was to make the `config` code more easy to add or delete fields, as well as make the code tidy. Those are trival things done by this PR:

* FIX the CMake error in target `unittest` while the redis_slot.o was missing in CMakeList.txt
* Rewrite would reserve the comment line and keep the position of fields
* Refactor the config `GET`, `SET` to make the code easy to add/delete a field, as well as friendly for human reading
* Some improvement about log messages
