### PR TITLE
FIX: dbsize scan and keys should scan the entire DB when the token is requirepass

### DIFF
--- a/src/redis_db.cc
+++ b/src/redis_db.cc
@@ -144,8 +144,10 @@ void Database::GetKeyNumStats(const std::string &prefix, KeyNumStats *stats) {
 
 void Database::Keys(std::string prefix, std::vector<std::string> *keys, KeyNumStats *stats) {
   std::string ns_prefix, ns, user_key, value;
-  AppendNamespacePrefix(prefix, &ns_prefix);
-  prefix = ns_prefix;
+  if (namespace_ != kDefaultNamespace || keys != nullptr) {
+    AppendNamespacePrefix(prefix, &ns_prefix);
+    prefix = ns_prefix;
+  }
 
   uint64_t ttl_sum = 0;
   LatestSnapShot ss(db_);


### PR DESCRIPTION
Resolved #33 