### PR TITLE
Fix/replication thread restart

### DIFF
--- a/src/redis_request.cc
+++ b/src/redis_request.cc
@@ -138,15 +138,16 @@ void Request::ExecuteCommands(Connection *conn) {
   if (commands_.empty()) return;
 
   Config *config = svr_->GetConfig();
-  std::string reply;
+  std::string reply, password;
+  password = conn->IsRepl() ? config->masterauth : config->requirepass;
   for (auto &cmd_tokens : commands_) {
     if (conn->IsFlagEnabled(Redis::Connection::kCloseAfterReply)) break;
     if (conn->GetNamespace().empty()) {
-      if (!config->requirepass.empty() && Util::ToLower(cmd_tokens.front()) != "auth") {
+      if (!password.empty() && Util::ToLower(cmd_tokens.front()) != "auth") {
         conn->Reply(Redis::Error("NOAUTH Authentication required."));
         continue;
       }
-      if (config->requirepass.empty()) {
+      if (password.empty()) {
         conn->BecomeAdmin();
         conn->SetNamespace(kDefaultNamespace);
       }

--- a/src/replication.cc
+++ b/src/replication.cc
@@ -495,7 +495,6 @@ ReplicationThread::CBState ReplicationThread::incrementBatchLoopCB(
             auto s = self->storage_->WriteBatch(std::string(bulk_data, self->incr_bulk_len_));
             if (!s.IsOK()) {
               LOG(ERROR) << "[replication] CRITICAL - Failed to write batch to local, " << s.Msg();
-              self->stop_flag_ = true;  // This is a very critical error, data might be corrupted
               return CBState::RESTART;
             }
             self->ParseWriteBatch(bulk_string);

--- a/src/server.cc
+++ b/src/server.cc
@@ -147,13 +147,6 @@ Status Server::RemoveMaster() {
   return Status::OK();
 }
 
-void Server::ResetMaster() {
-  slaveof_mu_.lock();
-  master_host_.clear();
-  master_port_ = 0;
-  slaveof_mu_.unlock();
-}
-
 Status Server::AddSlave(Redis::Connection *conn, rocksdb::SequenceNumber next_repl_seq) {
   auto t = new FeedSlaveThread(this, conn, next_repl_seq);
   auto s = t->Start();
@@ -549,7 +542,7 @@ void Server::GetReplicationInfo(std::string *info) {
     time(&now);
     string_stream << "master_host:" << master_host_ << "\r\n";
     string_stream << "master_port:" << master_port_ << "\r\n";
-    ReplState state = replication_thread_->State();
+    ReplState state = GetReplicationState();
     string_stream << "master_link_status:" << (state == kReplConnected? "up":"down") << "\r\n";
     string_stream << "master_sync_unrecoverable_error:" << (state == kReplError ? "yes" : "no") << "\r\n";
     string_stream << "master_sync_in_progress:" << (state == kReplFetchMeta || state == kReplFetchSST) << "\r\n";


### PR DESCRIPTION
1. Restart the replication thread when the slave use incorrect dbname/auth or failed to write to local
2. Fix the password in replication API, should use the masterauth instead of requirepass